### PR TITLE
configurando CORS para liberar acesso ao ghpages

### DIFF
--- a/src/main/java/br/unit/pe/GropesApplication.java
+++ b/src/main/java/br/unit/pe/GropesApplication.java
@@ -78,7 +78,11 @@ public class GropesApplication {
 			public void addCorsMappings(CorsRegistry registry) {
 				registry.addMapping("/**")
 				.allowedOrigins("http://localhost:4200")
-				.allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS", "HEAD", "TRACE", "CONNECT");;
+				.allowedMethods("GET", "POST", "OPTIONS", "HEAD", "TRACE", "CONNECT");
+				
+				registry.addMapping("/**")
+				.allowedOrigins("https://thiagojacinto.github.io")
+				.allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS", "HEAD", "TRACE", "CONNECT");
 			}
 		};
 	}


### PR DESCRIPTION
Adicionar ao mapping do CORS o domínio da aplicação frontend, permitindo a comunicação